### PR TITLE
Add missing NIP-05

### DIFF
--- a/.well-known/nostr.json
+++ b/.well-known/nostr.json
@@ -1,0 +1,13 @@
+{
+	"names": {
+		"_": "9c163c7351f8832b08b56cbb2e095960d1c5060dd6b0e461e813f0f07459119e"
+	},
+	"relays": {
+		"9c163c7351f8832b08b56cbb2e095960d1c5060dd6b0e461e813f0f07459119e": [
+			"wss://relay.damus.io/",
+			"wss://nostr-pub.wellorder.net/",
+			"wss://nostr.wine/",
+			"wss://nos.lol/"
+		]
+	}
+}


### PR DESCRIPTION
This PR adds the `.well-known/nostr.json` file according to [NIP-05](https://github.com/nostr-protocol/nips/blob/master/05.md) to make the NIP-05 address on `npub1nstrcu63lzpjkz94djajuz2evrgu2psd66cwgc0gz0c0qazezx0q9urg5l` valid
This also adds a few `relays` to the NIP-05 to help clients discover notes

Screenshot from [noStrudel](https://next.nostrudel.ninja/#/u/npub1nstrcu63lzpjkz94djajuz2evrgu2psd66cwgc0gz0c0qazezx0q9urg5l/about)
![image](https://github.com/user-attachments/assets/73a9c866-4773-4ce5-93fe-d81ff8a8b515)
